### PR TITLE
various enhancements

### DIFF
--- a/.aiidashellrc
+++ b/.aiidashellrc
@@ -1,0 +1,15 @@
+alias create bk backward
+alias create fw forward
+alias create vpl !verdi process list
+alias create vplp !verdi process list -P pk process_label label state scheduler_state
+alias create vcg !verdi calcjob gotocomputer
+alias create vpr !verdi process report
+alias create vp !verdi process
+alias create vco !verdi calcjob outputcat
+alias create vci !verdi calcjob inputcat
+alias create vdstart !verdi daemon start
+alias create vdstop !verdi daemon stop
+alias create vds !verdi daemon status
+alias create vdl !verdi daemon logshow
+
+

--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ The shell by default has no preloaded node, and the shell shows just the current
   to quick interaction with `verdi`.
   An example `.aiidashellrc` file is provided in the repository.
 
+## Konwn issues
+
+- The use of `verdi status` in the node shell without rabbitmq server running will cause CPU usage surge. 
+  This is probably because the python process does terminate, unlike that in the real `verdi` command. 
+
 ## Current status of the code and feedback
 I believe that the current code is already very useful, but it must be considered a first draft, to allow people to test
 the functionality and provide feedback.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and their attributes, extras and files in the repository.
 This is facilitated by a very fast interface. Indeed:
 
 - nodes are pre-loaded and multiple commands act by default on the "current node"
-- tab completion if *very* fast (ms vs a few hundresd of ms in `verdi`, since the database environment
+- tab completion is *very* fast (ms vs a few hundresd of ms in `verdi`, since the database environment
   and connections are setup only once when starting the shell.
 - tab completion is more customisable, e.g. showing the type of incoming/outgoing links together with the
   value to complete when inspecting links (commands `in` and `out`), or can properly browse directory and files
@@ -80,17 +80,17 @@ The shell by default has no preloaded node, and the shell shows just the current
 
 - Inspect all nodes that are incoming into the current node with the `in` command, showing the link type, the link label and the PK of the node. **Reminder**: you can jump to a node using the `load <PK>` command, making it easy to browse the graph. The output looks like:
     ```
-    - INPUT_CALC (settings) -> 1282
-    - INPUT_CALC (structure) -> 1211
-    - INPUT_CALC (pseudo_Al) -> 1527
-    - INPUT_CALC (code) -> 631
-    - INPUT_CALC (parameters) -> 1281
-    - INPUT_CALC (pseudo_Os) -> 1335
-    - INPUT_CALC (kpoints) -> 1197
+    # Link 0 - INPUT_CALC (settings) -> 1282
+    # Link 1 - INPUT_CALC (structure) -> 1211
+    # Link 2 - INPUT_CALC (pseudo_Al) -> 1527
+    # Link 3 - INPUT_CALC (code) -> 631
+    # Link 4 - INPUT_CALC (parameters) -> 1281
+    # Link 5 - INPUT_CALC (pseudo_Os) -> 1335
+    # Link 6 - INPUT_CALC (kpoints) -> 1197
     ```
 
 - Similarly, you can inspect outgoing nodes with `out`. Both for `in` and `out`, you can add a `-t` option to limit results to only one link type.
-
+- Note that the links are labelld by numbers. If you pass `-f <link id>` argument to the `in` command, it will bring you to the node connected by the link.
 - Browse the folders and files in the repository. You can check list files using `repo_ls`: 
 
     ```
@@ -119,6 +119,8 @@ The shell by default has no preloaded node, and the shell shows just the current
     ```   
   You can even redirect to file on your computer using `repo_cat aiida.in > test.txt` (and you can then show the file with bash commands by prepending with `!`, see also below): `!ls -l test.txt`, or `!cat test.txt`.
 
+- The report command prints the *report* for a process. It can be used for quick inspection of complex workchains.
+- The `show_hist` command shows a list the visited nodes, and you can quickly go back and forth usnig the `backward` and `forward` commands.  **NOTE** These commands may be renamed later.
 - There are also a set of useful things that are enabled by the `cmd2` library:
   - prepend a command with `!` to run in bash, for instance `!ls` to list the files in the current directory
   - you can run python commands with `run_pyscript`, or prepend by `@` (you can check all shortcuts with the `shortcuts` command)
@@ -134,6 +136,14 @@ The shell by default has no preloaded node, and the shell shows just the current
     ```
 
   to have the `rls` and `rcat` commands always available.
+  Note that you can also create alias for shell commands, such as
+
+    ```
+    alias create vplp !verdi process list -P pk process_label label state scheduler_state
+    ```
+
+  to quick interaction with `verdi`.
+  An example `.aiidashellrc` file is provided in the repository.
 
 ## Current status of the code and feedback
 I believe that the current code is already very useful, but it must be considered a first draft, to allow people to test

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and their attributes, extras and files in the repository.
 This is facilitated by a very fast interface. Indeed:
 
 - nodes are pre-loaded and multiple commands act by default on the "current node"
-- tab completion is *very* fast (ms vs a few hundresd of ms in `verdi`, since the database environment
+- tab completion is *very* fast (ms vs a few hundreds of ms in `verdi`, since the database environment
   and connections are setup only once when starting the shell.
 - tab completion is more customisable, e.g. showing the type of incoming/outgoing links together with the
   value to complete when inspecting links (commands `in` and `out`), or can properly browse directory and files
@@ -25,7 +25,7 @@ The goal is not to replace neither the python API nor the `verdi commands`, but 
 interface for a number of common tasks.
 
 ## Usage
-First, install the required dependencies in you virtual enviroment: `pip install -r requirements.txt`.
+First, install the required dependencies in you virtual environment: `pip install -r requirements.txt`.
 
 Then just execute the script (`./node_shell.py`) if you want to use the default profile in your environment.
 If you want to use a different profile, you can run with:
@@ -47,15 +47,15 @@ The shell by default has no preloaded node, and the shell shows just the current
 (in this example, the profile is called `default`).
 
 - Load a node, making it the current node: `load 1283` will load node with identifier 1283. 
-  Identifiers use the same logic as verdi, 
+  Identifiers use the same logic as verdi,
   [described here](https://aiida.readthedocs.io/projects/aiida-core/en/v1.0.1/verdi/verdi_user_guide.html#cli-identifiers)
   to specify PKs, UUIDs and/or labels.
 
-  The prompt now also indicates the type and PK of the current node: `(CalcJobNode<1283>@default) ` - Note that you can unload the node, if needed, with the `unload` command.
+  The prompt now also indicates the type and PK of the current node: `(CalcJobNode<1283>@default)` - Note that you can unload the node, if needed, with the `unload` command.
 
-- Let's check the last modification time with the command `mtime`: we get 
+- Let's check the last modification time with the command `mtime`: we get
 
-    ```
+    ```text
     Last modified 3 hours, 6 minutes ago (2020-02-19 10:46:49.307814+00:00)
     ```
 
@@ -65,7 +65,7 @@ The shell by default has no preloaded node, and the shell shows just the current
   
   - `attrkeys` to get a list of the keys of all attributes of the current node
   - `attr <attr_key>` to get the value of the attribute with key `<attr_key>`. You can use tab completion that will also show the type of the possible matching attributes! E.g. typing `attr re<TAB>` you get:
-    ```
+    ```text
     ATTRIBUTE_KEY             Description
     remote_workdir            (str)                                                                               
     resources                 (dict)                                                                              
@@ -90,7 +90,7 @@ The shell by default has no preloaded node, and the shell shows just the current
     ```
 
 - Similarly, you can inspect outgoing nodes with `out`. Both for `in` and `out`, you can add a `-t` option to limit results to only one link type.
-- Note that the links are labelld by numbers. If you pass `-f <link id>` argument to the `in` command, it will bring you to the node connected by the link.
+- Note that the links are labelled by numbers. If you pass `-l <link id>` argument to the `in` command, it will bring you to the node connected by the link.
 - Browse the folders and files in the repository. You can check list files using `repo_ls`: 
 
     ```
@@ -120,10 +120,25 @@ The shell by default has no preloaded node, and the shell shows just the current
   You can even redirect to file on your computer using `repo_cat aiida.in > test.txt` (and you can then show the file with bash commands by prepending with `!`, see also below): `!ls -l test.txt`, or `!cat test.txt`.
 
 - The report command prints the *report* for a process. It can be used for quick inspection of complex workchains.
-- The `show_hist` command shows a list the visited nodes, and you can quickly go back and forth usnig the `backward` and `forward` commands.  **NOTE** These commands may be renamed later.
+- The `nodehist_show` command shows a list the visited nodes with theiry relationships,
+  and you can quickly go back and forth using the `nodehist_backward` and `nodehist_forward` commands.
+
+  ```text
+  (ArrayData<30029>@demo) nodehist_show
+  CalcJobNode<30036> MyStructure RELAX 
+    🢁  ---  [structure] INPUT_CALC
+  StructureData<30030>  
+    🢁  ---  [structure] CREATE
+  CalcJobNode<30025> MyStructure RELAX 
+    🢁  ---  [CALL] CALL_CALC
+  WorkChainNode<30023> MyStructure RELAX 
+    🢃  ---  [energies] RETURN
+  ArrayData<30029>  <-- We are here
+  ```
+
 - There are also a set of useful things that are enabled by the `cmd2` library:
   - prepend a command with `!` to run in bash, for instance `!ls` to list the files in the current directory
-  - you can run python commands with `run_pyscript`, or prepend by `@` (you can check all shortcuts with the `shortcuts` command)
+  - you can run python commands with `run_pyscript`, or prepended by `@` (you can check all shortcuts with the `shortcuts` command)
   - exit the shell using `CTRL+D` or typing `exit` or `quit`
   - you can create command aliases, e.g. with `alias create rls repo_ls` to have a shorter alias for the `repo_ls` command (check also the `macro` command to also define aliases with argument placeholders)
   - edit a file using the `edit` command
@@ -136,19 +151,11 @@ The shell by default has no preloaded node, and the shell shows just the current
     ```
 
   to have the `rls` and `rcat` commands always available.
-  Note that you can also create alias for shell commands, such as
-
-    ```
-    alias create vplp !verdi process list -P pk process_label label state scheduler_state
-    ```
-
-  to quick interaction with `verdi`.
   An example `.aiidashellrc` file is provided in the repository.
 
 ## Konwn issues
 
-- The use of `verdi status` in the node shell without rabbitmq server running will cause CPU usage surge. 
-  This is probably because the python process does terminate, unlike that in the real `verdi` command. 
+- The use of `verdi status` in the node shell without the RabbitMQ server running will cause CPU usage surge. This is probably due a spawned thread getting stuck in a loop.
 
 ## Current status of the code and feedback
 I believe that the current code is already very useful, but it must be considered a first draft, to allow people to test

--- a/node_shell.py
+++ b/node_shell.py
@@ -148,11 +148,13 @@ class NodeHist:
         n_hist = len(self.node_history)
         current_pos = n_hist + self.node_history_pointer
         data_list = []
+        # Define the indentation
+        indent = ' | '
+        link_indent = '  '
         for i, hist in enumerate(self.node_history):
             here_mark = yellow('<-- We are here') if i == current_pos else ''
             node_line = '{} {} {}'.format(hist.desc, hist.node.label,
                                           here_mark)
-            link_lines = []
             if hist.linkinfo is not None:
                 # User unicode symbols for direction
                 if hist.linkinfo.direction == '<':
@@ -164,14 +166,12 @@ class NodeHist:
             else:
                 link_direction = '  ✖  '
                 link_line = ''
+            # Only add link if there is a previous node
             if i > 0:
-                link_line = link_direction + cyan(link_line)
-                data_list.append(link_line)
+                link_line = link_indent + link_direction + cyan(link_line)
+                data_list.append(indent + link_line)
 
-            # Only add link from the second node
-            if i > 0:
-                data_list.extend(link_lines)
-            data_list.append(node_line)
+            data_list.append(indent + node_line)
         if cmd is None:
             cmd2.ansi.style_aware_write(sys.stdout,
                                         '\n'.join(data_list) + '\n')

--- a/node_shell.py
+++ b/node_shell.py
@@ -10,6 +10,7 @@ a much more intuitive interface (even if more limited) than the python API.
 More details in the README.md file.
 
 Author: Giovanni Pizzi, EPFL
+Contributor: Bonan Zhu
 
 Version: 0.1
 """

--- a/node_shell.py
+++ b/node_shell.py
@@ -745,52 +745,46 @@ class AiiDANodeShell(cmd2.Cmd):
             print_exc(file=output)
 
     group_parser = cmd2.Cmd2ArgumentParser()
-    group_subparser = group_parser.add_subparsers(title='subcommands')
-    groupls_parser = group_subparser.add_parser('list', add_help=False)
 
-    groupls_parser.add_argument('--user-email', '-u', help='Filter by user')
-    groupls_parser.add_argument('--all-users',
+    group_parser.add_argument('--user-email', '-u', help='Filter by user')
+    group_parser.add_argument('--all-users',
                                 help='Flag if include all users',
                                 action='store_true')
-    groupls_parser.add_argument('--all-types',
+    group_parser.add_argument('--all-types',
                                 '-a',
                                 help='Flag if include all types',
                                 action='store_true')
-    groupls_parser.add_argument('--group-type',
+    group_parser.add_argument('--group-type',
                                 '-t',
                                 default=GroupTypeString.USER.value,
                                 help='Filter by type')
-    groupls_parser.add_argument('--with-description',
+    group_parser.add_argument('--with-description',
                                 '-d',
                                 help='Show also the decription',
                                 action='store_true')
-    groupls_parser.add_argument('--startswith',
+    group_parser.add_argument('--startswith',
                                 '-s',
                                 help='Filter by the initial string')
-    groupls_parser.add_argument('--endswith',
+    group_parser.add_argument('--endswith',
                                 '-e',
                                 help='Filter by ending string')
-    groupls_parser.add_argument(
+    group_parser.add_argument(
         '--contains',
         '-c',
         help='Filter by checking if the group name contains the string')
-    groupls_parser.add_argument(
+    group_parser.add_argument(
         '--past-days',
         '-p',
         type=int,
         help='Filter by only including those created in the past N days')
-    groupls_parser.add_argument(
+    group_parser.add_argument(
         '--count',
         '-C',
         action='store_true',
         help='Show also the number of nodes in the group')
 
-    groupbelong_parser = group_subparser.add_parser(
-        'belong',
-        help='List groups the current node belongs to.',
-        parents=[groupls_parser])
-
-    def group_list(self, args):
+    @cmd2.with_argparser(group_parser)
+    def do_group_list(self, args):
         """Command for list groups"""
         from aiida.cmdline.commands.cmd_group import group_list
         group_list.callback(all_users=args.all_users,
@@ -805,7 +799,8 @@ class AiiDANodeShell(cmd2.Cmd):
                             contains=args.contains,
                             node=None)
 
-    def group_belong(self, args):
+    @cmd2.with_argparser(group_parser)
+    def do_group_belong(self, args):
         """Command for list groups"""
         from aiida.cmdline.commands.cmd_group import group_list
         group_list.callback(all_users=args.all_users,
@@ -819,18 +814,6 @@ class AiiDANodeShell(cmd2.Cmd):
                             endswith=args.endswith,
                             contains=args.contains,
                             node=self._current_node)
-
-    groupls_parser.set_defaults(func=group_list)
-    groupbelong_parser.set_defaults(func=group_belong)
-
-    @cmd2.with_argparser(group_parser)
-    def do_group(self, args):
-        """Group command"""
-        func = getattr(args, 'func', None)
-        if func is not None:
-            func(self, args)
-        else:
-            self.do_help('group')
 
 
 def expand_node_subsitute(arg, hist_obj):

--- a/node_shell.py
+++ b/node_shell.py
@@ -95,10 +95,8 @@ def needs_new_node(always=False):
                 if isinstance(current_node, ProcessNode):
                     if not current_node.is_sealed:
                         self.do_reload('')
-                return f(self, *args, **kwds)
-
+            return f(self, *args, **kwds)
         return wrapper
-
     return _wrapper
 
 
@@ -906,9 +904,10 @@ class AiiDANodeShell(cmd2.Cmd):
         added_env['_VERDI_COMPLETE'] = "complete-bash"
 
         # Prepare the pieces
-        comp_words = "verdi " + " ".join(shlex.quote(arg_piece) for arg_piece in arg_pieces)
+        comp_words = "verdi " + " ".join(
+            shlex.quote(arg_piece) for arg_piece in arg_pieces)
         pos = len(arg_pieces)
-        added_env['COMP_WORDS']= comp_words
+        added_env['COMP_WORDS'] = comp_words
         added_env['COMP_CWORD'] = str(pos)
 
         try:
@@ -929,7 +928,9 @@ class AiiDANodeShell(cmd2.Cmd):
             # - a double quote
             # - a single quote
             # open and closed brackets: ( )
-            pieces = [re.sub(r"""\\([\s\\"'()])""", r'\1', piece) for piece in pieces]
+            pieces = [
+                re.sub(r"""\\([\s\\"'()])""", r'\1', piece) for piece in pieces
+            ]
             return pieces
         except Exception:
             ## IGNORE EXCEPTIONS DURING COMPLETION
@@ -939,12 +940,14 @@ class AiiDANodeShell(cmd2.Cmd):
             return []
         return []
 
-    def verdi_args_completer_method(self, text, line, begidx, endidx, arg_tokens):  # pylint: disable=too-many-arguments
+    def verdi_args_completer_method(self, text, line, begidx, endidx,
+                                    arg_tokens):  # pylint: disable=too-many-arguments
         """Method to perform completion for the 'verdi' command.
 
         This pipes through the Bash completion via click."""
         match_against = self.get_verdi_completion(arg_tokens['args'])
-        complete_vals = basic_complete(text, line, begidx, endidx, match_against)
+        complete_vals = basic_complete(text, line, begidx, endidx,
+                                       match_against)
         # This apparently happens if there is no completion
         # Actually in bash this sometimes triggers file completion; to check
         # if we want to investigate using self.path_complete here (but it does not
@@ -954,9 +957,11 @@ class AiiDANodeShell(cmd2.Cmd):
         return complete_vals
 
     verdi_complete_parser = cmd2.Cmd2ArgumentParser()
-    verdi_complete_parser.add_argument('args', nargs=argparse.REMAINDER,
-                                    suppress_tab_hint=True,
-                                    completer_method=verdi_args_completer_method)
+    verdi_complete_parser.add_argument(
+        'args',
+        nargs=argparse.REMAINDER,
+        suppress_tab_hint=True,
+        completer_method=verdi_args_completer_method)
 
     @cmd2.with_argparser(verdi_complete_parser)
     def do_verdi(self, arg):
@@ -971,7 +976,10 @@ class AiiDANodeShell(cmd2.Cmd):
         # command won't work for the node shell launched with non-default profile
         verdi_args = ['-p', self.current_profile]
         try:
-            passed_args = [expand_node_subsitute(the_arg, self._node_hist) for the_arg in arg.args]
+            passed_args = [
+                expand_node_subsitute(the_arg, self._node_hist)
+                for the_arg in arg.args
+            ]
         except RuntimeError as exc:
             self.poutput(str(exc))
             return
@@ -1169,13 +1177,15 @@ def expand_node_subsitute(arg, hist_obj):
             node = hist_obj.node_history[pointer].node
         except IndexError:
             if hist_obj.node_history:
-                how_many = (
-                    "are {} nodes".format(len(hist_obj.node_history)) if len(hist_obj.node_history) != 1
-                    else "is 1 node")
+                how_many = ("are {} nodes".format(len(hist_obj.node_history))
+                            if len(hist_obj.node_history) != 1 else
+                            "is 1 node")
                 raise RuntimeError(
-            'Invalid offset in argument "{}" for node history '
-            '(there {} in the history)'.format(arg, how_many))
-            raise RuntimeError('No node in node history, you need to load a node before using it in argument "{}"'.format(arg))
+                    'Invalid offset in argument "{}" for node history '
+                    '(there {} in the history)'.format(arg, how_many))
+            raise RuntimeError(
+                'No node in node history, you need to load a node before using it in argument "{}"'
+                .format(arg))
 
         # Replace the line
         else:

--- a/node_shell.py
+++ b/node_shell.py
@@ -724,10 +724,14 @@ class AiiDANodeShell(cmd2.Cmd):
             # Passing -p is not allowed, we can only use the current profile
             if passed_args[0] in ('-p', '--profile'):
                 print(
-                    'Error: Manual profile selection is not allowed in the node shell.',
+                    red('Error: ') + 
+                    'Manual profile selection is not allowed in the node shell.',
+                    file=output)
+                print(
+                     'To switch profile, relaunch the node shell with verdi -p <profile} run.',
                     file=output)
                 print('Your current profile is: {}'.format(
-                    self.current_profile),
+                    green(self.current_profile)),
                       file=output)
                 return
 

--- a/node_shell.py
+++ b/node_shell.py
@@ -376,6 +376,11 @@ class AiiDANodeShell(cmd2.Cmd):
                              help='Filter by link type',
                              choices=LINK_TYPES)
 
+    link_parser.add_argument('-f',
+                             '--follow',
+                             help='Follow this link to the next node',
+                             type=int)
+
     @needs_node
     @cmd2.with_argparser(link_parser)
     def do_in(self, arg):
@@ -392,10 +397,14 @@ class AiiDANodeShell(cmd2.Cmd):
         if not incomings:
             print("No incoming links{}".format(type_filter_string))
             return
-        for incoming in incomings:
-            print("- {} ({}) -> {}".format(incoming.link_type.value.upper(),
-                                           incoming.link_label,
-                                           incoming.node.pk))
+        if arg.follow is None:
+            for ilink, incoming in enumerate(incomings):
+                print("Link #{} - {} ({}) -> {}".format(ilink, incoming.link_type.value.upper(),
+                                            incoming.link_label,
+                                            incoming.node.pk))
+        else:
+            next_pk = incomings[arg.follow].node.pk
+            self.do_load(next_pk)
 
     @needs_node
     @cmd2.with_argparser(link_parser)
@@ -415,10 +424,14 @@ class AiiDANodeShell(cmd2.Cmd):
         if not outgoings:
             print("No outgoing links{}".format(type_filter_string))
             return
-        for outgoing in outgoings:
-            print("- {} ({}) -> {}".format(outgoing.link_type.value.upper(),
-                                           outgoing.link_label,
-                                           outgoing.node.pk))
+        if arg.follow is None:
+            for ilink, outgoing in enumerate(outgoings):
+                print("Link #{} - {} ({}) -> {}".format(ilink, outgoing.link_type.value.upper(),
+                                            outgoing.link_label,
+                                            outgoing.node.pk))
+        else:
+            next_pk = outgoings[arg.follow].node.pk
+            self.do_load(next_pk)
 
     @needs_node
     @with_default_argparse

--- a/node_shell.py
+++ b/node_shell.py
@@ -96,7 +96,9 @@ def needs_new_node(always=False):
                     if not current_node.is_sealed:
                         self.do_reload('')
             return f(self, *args, **kwds)
+
         return wrapper
+
     return _wrapper
 
 
@@ -586,7 +588,7 @@ class AiiDANodeShell(cmd2.Cmd):
         for key in sorted(extras_keys):
             self.poutput('- {}'.format(key))
 
-    @needs_new_node(always=True)
+    @needs_new_node()
     @with_default_argparse
     def do_attrs(self, arg):  # pylint: disable=unused-argument
         """Show all attributes (keys and values) of the current node."""
@@ -618,7 +620,7 @@ class AiiDANodeShell(cmd2.Cmd):
                                 help='The attribute key',
                                 choices_method=attrs_choices_method)
 
-    @needs_new_node(always=True)
+    @needs_new_node()
     @cmd2.with_argparser(attrkey_parser)
     def do_attr(self, arg):
         """Show one attribute of the current node."""
@@ -630,7 +632,7 @@ class AiiDANodeShell(cmd2.Cmd):
             self.poutput("No attribute with key '{}'".format(
                 arg.attribute_key))
 
-    @needs_new_node(always=True)
+    @needs_new_node()
     @with_default_argparse
     def do_attrkeys(self, arg):  # pylint: disable=unused-argument
         """Show the keys of all attributes of the current node."""
@@ -1092,9 +1094,6 @@ class AiiDANodeShell(cmd2.Cmd):
             """
             from aiida.cmdline.utils.shell import get_start_namespace
             from IPython import embed
-            from traitlets.config import get_config
-            conf = get_config()
-            conf.InteractiveShellEmbed.colors = "Linux"
 
             # Create a variable pointing to py_bridge
             exec("{} = py_bridge".format(cmd2_app.py_bridge_name))
@@ -1113,13 +1112,19 @@ class AiiDANodeShell(cmd2.Cmd):
             del py_bridge
 
             # Start ipy shell
-            embed(banner1=(
+            banner = (
                 'Entering an embedded verdi shell. Type quit or <Ctrl>-d to exit.\n'
-                'Run Python code from external files with: run filename.py\n'
-                'The loaded node \'{}\' can be accessed with \'current_node\'\n'
-                .format(_cnode_string)),
-                  exit_msg='Leaving verdi shell, back to the node shell',
-                  config=conf)
+                'Run Python code from external files with: run filename.py\n')
+
+            if _cnode_string:
+                banner += 'The loaded node \'{}\' can be accessed with \'current_node\'\n'.format(
+                    _cnode_string)
+
+            embed(
+                banner1=banner,
+                exit_msg='Leaving verdi shell, back to the node shell',
+                colors='Neutral',
+            )
 
         if self.in_pyscript():
             self.perror(

--- a/node_shell.py
+++ b/node_shell.py
@@ -18,11 +18,13 @@ import functools
 from datetime import datetime
 import pytz
 import sys
+from traceback import print_exc
 
 from ago import human
 import click
 
 from aiida.common.links import LinkType
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.orm.utils.repository import FileType
 from pprint import pformat
 
@@ -589,6 +591,24 @@ class AiiDANodeShell(cmd2.Cmd):
     #    #line = line.lower()
     #    return line
 
+    def do_verdi(self, arg):
+        """Run verdi commands using the current profile"""
+        output = self.stdout
+
+        # Here I force verdi to use the current profile, otherwise the
+        # command won't work for the node shell launched with non-default profile
+        verdi_args = ['-p', self.current_profile]
+        verdi_args.extend(arg.split())
+        try:
+            verdi.main(args=verdi_args)
+        except SystemExit as e:
+            # SystemExit means the command-line tool finished as intented
+            # No action needed
+            pass
+        except Exception as e:
+            # Catch all python exceptions raised during the verdi command execution
+            print('Verdi Command raised an exception {}'.format(e), file=output)
+            print_exc(file=output)
 
 if __name__ == '__main__':
     import os

--- a/node_shell.py
+++ b/node_shell.py
@@ -116,7 +116,7 @@ class NodeHist:
     def set_current(self, node, desc):
         """Set the current node"""
         if self.node_history and self.node_history[
-                self.node_history_pointer].node == node:
+                self.node_history_pointer].node.pk == node.pk:
             # Loading the current node - do nothing
             return
         # Otherwise we append the node to the history
@@ -174,7 +174,8 @@ class NodeHist:
                 data_list.extend(link_lines)
             data_list.append(node_line)
         if cmd is None:
-            cmd2.ansi.style_aware_write(sys.stdout, '\n'.join(data_list) + '\n')
+            cmd2.ansi.style_aware_write(sys.stdout,
+                                        '\n'.join(data_list) + '\n')
         else:
             cmd.poutput('\n'.join(data_list))
 
@@ -275,7 +276,9 @@ class AiiDANodeShell(cmd2.Cmd):
         return '({}) '.format(self.current_profile)
 
     load_parser = cmd2.Cmd2ArgumentParser()
-    load_parser.add_argument('identifier', help='Identifier for loading the node')
+    load_parser.add_argument('identifier',
+                             help='Identifier for loading the node')
+
     @cmd2.with_argparser(load_parser)
     def do_load(self, arg):
         """Load a node in the shell, making it the 'current node'."""
@@ -776,7 +779,10 @@ class AiiDANodeShell(cmd2.Cmd):
 
     graph_gen_parser = cmd2.Cmd2ArgumentParser()
     graph_gen_parser.add_argument('--link-types', '-l', default='all')
-    graph_gen_parser.add_argument('--identifier', default='uuid',)
+    graph_gen_parser.add_argument(
+        '--identifier',
+        default='uuid',
+    )
     graph_gen_parser.add_argument('--ancestor-depth', type=int)
     graph_gen_parser.add_argument('--descendant-depth', type=int)
     graph_gen_parser.add_argument('--process-out', action='store_true')
@@ -785,6 +791,7 @@ class AiiDANodeShell(cmd2.Cmd):
     graph_gen_parser.add_argument('--engine', '-e', default='dot')
     graph_gen_parser.add_argument('--output-format', '-f', default='pdf')
     graph_gen_parser.add_argument('--show', '-s', action='store_true')
+
     @needs_new_node
     @cmd2.with_argparser(graph_gen_parser)
     def do_graph_generate(self, arg):
@@ -793,19 +800,17 @@ class AiiDANodeShell(cmd2.Cmd):
         """
         from aiida.cmdline.commands.cmd_node import graph_generate
         with self.verdi_isolate():
-            graph_generate.callback(
-                root_node=self._current_node,
-                link_types=arg.link_types,
-                identifier=arg.identifier,
-                ancestor_depth=arg.ancestor_depth,
-                descendant_depth=arg.descendant_depth,
-                process_out=arg.process_out,
-                process_in=arg.process_in,
-                engine=arg.engine,
-                verbose=arg.verbose,
-                output_format=arg.output_format,
-                show=arg.show
-            )
+            graph_generate.callback(root_node=self._current_node,
+                                    link_types=arg.link_types,
+                                    identifier=arg.identifier,
+                                    ancestor_depth=arg.ancestor_depth,
+                                    descendant_depth=arg.descendant_depth,
+                                    process_out=arg.process_out,
+                                    process_in=arg.process_in,
+                                    engine=arg.engine,
+                                    verbose=arg.verbose,
+                                    output_format=arg.output_format,
+                                    show=arg.show)
 
     #def precmd(self, line):
     #    'To be implemented in case we want to manipulate the line'

--- a/node_shell.py
+++ b/node_shell.py
@@ -808,20 +808,29 @@ class AiiDANodeShell(cmd2.Cmd):
                             default='.',
                             help="The path to the file to output",
                             completer_method=repo_cat_completer_method)
+    cat_parser.add_argument('--byte',
+                            '-b',
+                            help='Open in byte mode',
+                            action='store_true')
 
     @needs_node
     @cmd2.with_argparser(cat_parser)
     def do_repo_cat(self, arg):
         """Echo on screen the content of a file in the repository of the current node."""
+        mode = 'rb' if arg.byte else 'r'
         try:
-            content = self._current_node.get_object_content(arg.PATH)
+            content = self._current_node.get_object_content(arg.PATH,
+                                                            mode=mode)
         except IsADirectoryError:
             self.perror("Error: '{}' is a directory".format(arg.PATH))
         except FileNotFoundError:
             self.perror("Error: '{}' not found if node repository".format(
                 arg.PATH))
         else:
-            self.stdout.write(content)
+            if mode == 'rb':
+                self.stdout.buffer.write(content)
+            else:
+                self.stdout.write(content)
 
     @with_default_argparse
     @needs_node

--- a/node_shell.py
+++ b/node_shell.py
@@ -935,6 +935,18 @@ class AiiDANodeShell(cmd2.Cmd):
                                 contains=args.contains,
                                 node=self._current_node)
 
+    def do_cd(self, args):
+        """Change directory"""
+        path = args
+        if not path:
+            path = os.path.expanduser("~")
+        os.chdir(path)
+
+    @with_default_argparse
+    def do_pwd(self, arg):
+        """Return the current workding directory"""
+        self.poutput(os.getcwd())
+
     @contextlib.contextmanager
     def verdi_isolate(self):
         """A context manager that sets up the isolation for invoking of a

--- a/node_shell.py
+++ b/node_shell.py
@@ -403,6 +403,10 @@ class AiiDANodeShell(cmd2.Cmd):
                                             incoming.link_label,
                                             incoming.node.pk))
         else:
+            if arg.follow >= len(incomings) or arg.follow < 0:
+                print("Error: invalid link id {}".format(arg.follow))
+                return
+
             next_pk = incomings[arg.follow].node.pk
             self.do_load(next_pk)
 
@@ -430,6 +434,9 @@ class AiiDANodeShell(cmd2.Cmd):
                                             outgoing.link_label,
                                             outgoing.node.pk))
         else:
+            if arg.follow >= len(outgoings) or arg.follow < 0:
+                print("Error: invalid link id {}".format(arg.follow))
+                return
             next_pk = outgoings[arg.follow].node.pk
             self.do_load(next_pk)
 

--- a/node_shell.py
+++ b/node_shell.py
@@ -71,8 +71,7 @@ def needs_node(f):
 
 
 def needs_new_node(f):
-    """
-    Decorator to mark the command prefers to have the node reloaded.
+    """Decorator to mark the command prefers to have the node reloaded.
     The node will be only be reloaded if it is an unsealed ProcessNode.
     """
     @needs_node
@@ -883,8 +882,7 @@ class AiiDANodeShell(cmd2.Cmd):
     #    #line = line.lower()
     #    return line
     def do_verdi(self, arg):
-        """
-        Run verdi commands using the current profile.
+        """Run verdi commands using the current profile.
         The argument will be passed to ``verdi`` as it is, except that {} will be 
         expanded to the currently loaded node's pk.
         You may reference other nodes in the load history using offsets in {}.
@@ -1016,15 +1014,13 @@ class AiiDANodeShell(cmd2.Cmd):
         self.poutput(os.getcwd())
 
     @with_default_argparse
-    def do_verdi_shell(self, _):
-        """
-        Enter an ipython shell simimlar to that launched by `verdi shell`
+    def do_vshell(self, _):
+        """Enter an ipython shell simimlar to that launched by `verdi shell`
         """
         from cmd2.py_bridge import PyBridge
 
         def load_ipy(cmd2_app, py_bridge):
-            """
-            Embed an IPython shell in an environment that is restricted to only the variables in this function
+            """Embed an IPython shell in an environment that is restricted to only the variables in this function
             :param cmd2_app: instance of the cmd2 app
             :param py_bridge: a PyBridge
             """
@@ -1088,8 +1084,7 @@ class AiiDANodeShell(cmd2.Cmd):
 
 
 def expand_node_subsitute(arg, hist_obj):
-    """
-    Expand the subsitution for node PK in the argument.
+    """Expand the subsitution for node PK in the argument.
     {} expands to node_history[current_pos].pk
     {n} expands to node_history[current_pos + n].pk
     """

--- a/node_shell.py
+++ b/node_shell.py
@@ -19,16 +19,21 @@ from cmd2 import ansi
 import functools
 from datetime import datetime
 import pytz
+import io
 import sys
+import os
 import re
+import shlex
 from traceback import print_exc
 from pprint import pformat
 from collections import namedtuple
 import contextlib
+import argparse
 
 from ago import human
 import click
 
+from cmd2.utils import basic_complete
 from aiida.common.links import LinkType
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.orm.utils.repository import FileType
@@ -228,6 +233,20 @@ class AiiDANodeShell(cmd2.Cmd):
 
     def __init__(self, *args, node_identifier=None, **kwargs):
         """Initialise a shell, possibly with a given node preloaded."""
+        from aiida.manage.configuration import get_config
+
+        # If I can reach the AiiDA config directory, I set a history
+        # In this way, the history is different if different
+        # virtualenvs define a different AIIDA_PATH. Note that this is
+        # still the same for all profiles in that virtualenv (which is
+        # probably OK). Otherwise we would need to insert the profile
+        # name in the history file to have a different history per profile,
+        # but probably this is not needed.
+        aiida_config_dir_path = get_config().dirpath
+        if os.path.isdir(aiida_config_dir_path):
+            kwargs['persistent_history_file'] = os.path.join(
+                aiida_config_dir_path, 'node-shell-history.dat')
+
         super().__init__(*args, use_ipython=True, **kwargs)
         self.self_in_py = True
         self.allow_style = cmd2.ansi.STYLE_TERMINAL
@@ -241,20 +260,23 @@ class AiiDANodeShell(cmd2.Cmd):
         self._current_node = NodeEntityLoader.load_entity(identifier)
 
     @property
-    def current_profile(self):
-        """Return a string with the current profile name (or 'NO_PROFILE' if no profile is loaded)."""
+    def _current_profile_object(self):
+        """Get the current AiiDA profile object, or None if not set."""
         from aiida.manage.configuration import get_config
 
         # Caching
         if not self._current_profile:
-            current_profile = get_config().current_profile
-            if current_profile:
-                self._current_profile = current_profile.name
-
-        if not self._current_profile:
-            return "NO_PROFILE"
+            self._current_profile = get_config().current_profile
 
         return self._current_profile
+
+    @property
+    def current_profile(self):
+        """Return a string with the current profile name (or 'NO_PROFILE' if no profile is loaded)."""
+        current_profile_object = self._current_profile_object
+        if not current_profile_object:
+            return "NO_PROFILE"
+        return current_profile_object.name
 
     def _get_node_string(self, node=None):
         """Return a string representing the current node (to be used in the prompt)."""
@@ -890,6 +912,81 @@ class AiiDANodeShell(cmd2.Cmd):
     #    'To be implemented in case we want to manipulate the line'
     #    #line = line.lower()
     #    return line
+
+    def get_verdi_completion(self, arg_pieces):
+        """Call the click verdi completion command.
+
+        This requires preparing the environment as reqired by click when going
+        through bash completion.
+
+        Note if you are looking into the code: don't look only in click, but also
+        in the code mokey-patched by click-completion!
+        https://github.com/click-contrib/click-completion/blob/master/click_completion/patch.py
+
+        For this reason, for now I go via the BASH environment variables, that seems
+        less prone to code changes in the immediate future.
+        """
+        # Additional environment variables
+        added_env = {}
+        # Use a TAB as a separator
+        added_env['IFS'] = r"$'\t'"
+        # Variable needed by click to perform tab completion
+        added_env['_VERDI_COMPLETE'] = "complete-bash"
+
+        # Prepare the pieces
+        comp_words = "verdi " + " ".join(shlex.quote(arg_piece) for arg_piece in arg_pieces)
+        pos = len(arg_pieces)
+        added_env['COMP_WORDS']= comp_words
+        added_env['COMP_CWORD'] = str(pos)
+
+        try:
+            my_stdout = io.StringIO()
+            with self.verdi_isolate(added_env, my_stdout):
+                verdi.main(args=[], prog_name='verdi')
+        except SystemExit:
+            # SystemExit means the command-line tool finished as intented
+            my_stdout.seek(0)
+            pieces = my_stdout.read().split('\t')
+            # Manual attempt to unescape... Not perfect, and might break in the future :-(
+            # But for now I'm reverting what is done here:
+            # https://github.com/click-contrib/click-completion/blob/6e08a5fa43149c822152d40c07e00be5ec2c5c7e/click_completion/core.py#L170
+            # namely re.sub(r"""([\s\\"'()])""", r'\\\1', opt)
+            # i.e. it's prepending a backslash to the following characters:
+            # - a space-like character
+            # - a backslash
+            # - a double quote
+            # - a single quote
+            # open and closed brackets: ( )
+            pieces = [re.sub(r"""\\([\s\\"'()])""", r'\1', piece) for piece in pieces]
+            return pieces
+        except Exception:
+            ## IGNORE EXCEPTIONS DURING COMPLETION
+            # In any case, it'd be good if quickly fix this issue first:
+            # https://github.com/aiidateam/aiida-core/issues/3815
+            # (but I would still keep this logic here to ignore possible exceptions)
+            return []
+        return []
+
+    def verdi_args_completer_method(self, text, line, begidx, endidx, arg_tokens):  # pylint: disable=too-many-arguments
+        """Method to perform completion for the 'verdi' command.
+
+        This pipes through the Bash completion via click."""
+        match_against = self.get_verdi_completion(arg_tokens['args'])
+        complete_vals = basic_complete(text, line, begidx, endidx, match_against)
+        # This apparently happens if there is no completion
+        # Actually in bash this sometimes triggers file completion; to check
+        # if we want to investigate using self.path_complete here (but it does not
+        # make sense in many cases, see e.g. 'verdi group list')
+        if complete_vals == ['']:
+            complete_vals = []
+        return complete_vals
+
+    verdi_complete_parser = cmd2.Cmd2ArgumentParser()
+    verdi_complete_parser.add_argument('args', nargs=argparse.REMAINDER,
+                                    suppress_tab_hint=True,
+                                    completer_method=verdi_args_completer_method)
+
+    @cmd2.with_argparser(verdi_complete_parser)
     def do_verdi(self, arg):
         """Run verdi commands using the current profile.
         The argument will be passed to ``verdi`` as it is, except that {} will be 
@@ -901,7 +998,11 @@ class AiiDANodeShell(cmd2.Cmd):
         # Here I force verdi to use the current profile, otherwise the
         # command won't work for the node shell launched with non-default profile
         verdi_args = ['-p', self.current_profile]
-        passed_args = expand_node_subsitute(arg, self._node_hist).split()
+        try:
+            passed_args = [expand_node_subsitute(the_arg, self._node_hist) for the_arg in arg.args]
+        except RuntimeError as exc:
+            self.poutput(str(exc))
+            return
 
         if passed_args:
             # Print help for this command (not verdi)
@@ -1075,21 +1176,29 @@ class AiiDANodeShell(cmd2.Cmd):
             self._in_py = False
 
     @contextlib.contextmanager
-    def verdi_isolate(self):
+    def verdi_isolate(self, new_env_vars=None, custom_stdout=None):
         """A context manager that sets up the isolation for invoking of a
         command line tool. The sys.stdin and sys.sydout are temporarily redirected
         to self.stdout, self.stderr. This is useful for calling verdi commends that
         writes directly to stdout and stderr
         """
-
         old_stdout = sys.stdout
+        old_env = os.environ.copy()
 
-        sys.stdout = self.stdout
+        if new_env_vars:
+            for key, val in new_env_vars.items():
+                os.environ[key] = val
+
+        if custom_stdout:
+            sys.stdout = custom_stdout
+        else:
+            sys.stdout = self.stdout
 
         try:
             yield
         finally:
             sys.stdout = old_stdout
+            os.environ = old_env
 
 
 def expand_node_subsitute(arg, hist_obj):
@@ -1108,8 +1217,15 @@ def expand_node_subsitute(arg, hist_obj):
         try:
             node = hist_obj.node_history[pointer].node
         except IndexError:
-            raise RuntimeError('Invalid offset {} in argument {}'.format(
-                pointer, arg))
+            if hist_obj.node_history:
+                how_many = (
+                    "are {} nodes".format(len(hist_obj.node_history)) if len(hist_obj.node_history) != 1
+                    else "is 1 node")
+                raise RuntimeError(
+            'Invalid offset in argument "{}" for node history '
+            '(there {} in the history)'.format(arg, how_many))
+            raise RuntimeError('No node in node history, you need to load a node before using it in argument "{}"'.format(arg))
+
         # Replace the line
         else:
             arg = arg.replace(whole_str, str(node.pk))
@@ -1137,7 +1253,9 @@ if __name__ == '__main__':
 
         while True:
             try:
-                sys.exit(shell.cmdloop())
+                retcode = shell.cmdloop()
+                print()
+                sys.exit(retcode)
                 break
             except KeyboardInterrupt:  # CTRL+C pressed
                 # Ignore CTRL+C


### PR DESCRIPTION
I think it would be a good time to raise and PR, as discussed in the meeting I have added a few commands and I will add more/change the existing accordingly. 

This PR is a work-in-progress and mainly act as a potential place of discussion and progress tracking.

Changes: 

- [x] Access to `verdi` commands -  I have made the entire `verdi` command accessible in the node shell using the native `click` interface. It is very fast, but there is no autocompletion. I also added expansion so `{}` expands to the current node's pk and `{-1}` expands to that of the last node in the history.
- [x] Access to `verdi shell` using `vshell` command. This start an embedded IPython shell with pre-loaded aiida objects in local scope similar to that of `verdi shell`
- [x] `cd` and `pwd` command for switching directories
- [x] `do_in` , `do_out` stable order and rename `-l/--follow-link-id` and coloring
- [x] make `nodehist_show` display relationships
- [x] add `group_list` and `group_belong` commands
- [x] `-set` options for `label` and `description` commands
- [x] `reload` command for reloading the node and `needs_new_node` decorator so some commands can automatically reload unsealed `ProcessNode`. 
- [x] `comment_add` and `comment_show` commands. 

Konwn Issues:
- `verdi status` will surge CPU usage is rabbitmq is not running - this is probably a problem in the actual `verdi status` command since it was assumed that the python process should terminate after the command execution. 

This PR address: 
- #1 
- #2 
- #3 
